### PR TITLE
RoP course page should not have membership

### DIFF
--- a/src/collections/courses.ts
+++ b/src/collections/courses.ts
@@ -5,6 +5,7 @@ export default defineCollection({
   schema: ({ image }) =>
     z
       .object({
+        includedInMembership: z.boolean().default(true),
         archived: z.boolean().default(false),
         bundledCourses: z
           .array(reference("courses"))

--- a/src/content/courses/typelevel-rite-of-passage/index.mdx
+++ b/src/content/courses/typelevel-rite-of-passage/index.mdx
@@ -1,4 +1,5 @@
 ---
+includedInMembership: false
 benefits:
   hours: 35
   linesOfCode: 6200

--- a/src/content/courses/zio-rite-of-passage/index.mdx
+++ b/src/content/courses/zio-rite-of-passage/index.mdx
@@ -1,4 +1,5 @@
 ---
+includedInMembership: false
 benefits:
   hours: 30
   linesOfCode: 6200

--- a/src/pages/courses/_layouts/CourseLayout.astro
+++ b/src/pages/courses/_layouts/CourseLayout.astro
@@ -44,6 +44,7 @@ const [bundledCourses, _categoryFrontmatter, collaborators] = await Promise.all(
 );
 const { color: categoryColor, faqs: categoryFaqs } = _categoryFrontmatter;
 const {
+  includedInMembership,
   benefits,
   description,
   faqs,
@@ -143,6 +144,7 @@ const structuredData = {
       )
     }
     <Pricing
+      {includedInMembership}
       {benefits}
       {bundledCourses}
       color={categoryColor}

--- a/src/pages/courses/_sections/Pricing.astro
+++ b/src/pages/courses/_sections/Pricing.astro
@@ -10,6 +10,7 @@ import CoursePrice from "../_components/CoursePrice";
 type CourseFrontmatter = CollectionEntry<"courses">["data"];
 
 interface Props {
+  includedInMembership: CourseFrontmatter["includedInMembership"];
   benefits: CourseFrontmatter["benefits"];
   bundledCourses: CollectionEntry<"courses">[];
   courseSlug: CollectionEntry<"courses">["slug"];
@@ -18,8 +19,15 @@ interface Props {
   title: CourseFrontmatter["title"];
 }
 
-const { benefits, bundledCourses, color, courseSlug, pricingPlanId, title } =
-  Astro.props;
+const {
+  includedInMembership,
+  benefits,
+  bundledCourses,
+  color,
+  courseSlug,
+  pricingPlanId,
+  title,
+} = Astro.props;
 const monthlyMembershipPricingPlanId = (
   await getEntry("memberships", "personal")
 ).data.packages[0].pricingPlanId;
@@ -46,6 +54,10 @@ const categories = (await getCollection("courseCategories"))
 const featuredBundles = _courses.filter((course) =>
   course.data.bundledCourses?.some((course) => course.slug === courseSlug),
 );
+// remove this when including the RoP courses in the membership
+const membershipIncludedClassNames = includedInMembership && "grid grid-cols-1";
+const membershipIncludedCardClassNames =
+  includedInMembership && "sm:rounded-b-none lg:rounded-tr-none";
 ---
 
 <Section
@@ -57,10 +69,10 @@ const featuredBundles = _courses.filter((course) =>
   <div class="relative isolate w-full px-6 py-1 sm:py-2 lg:px-8">
     <div class="mx-auto max-w-2xl text-center lg:max-w-4xl"></div>
     <div
-      class="mx-auto mt-16 grid max-w-lg grid-cols-1 items-center gap-y-6 sm:mt-20 sm:gap-y-0 lg:max-w-4xl lg:grid-cols-2"
+      class=`mx-auto mt-16 max-w-lg items-center gap-y-6 sm:mt-20 sm:gap-y-0 lg:max-w-4xl lg:grid-cols-2 ${membershipIncludedClassNames}`
     >
       <div
-        class="card-shadow card-shadow-color rounded-3xl bg-secondary/60 p-8 ring-1 ring-content-2/10 sm:mx-8 sm:rounded-b-none sm:p-10 lg:mx-0 lg:rounded-bl-3xl lg:rounded-tr-none"
+        class=`card-shadow card-shadow-color rounded-3xl bg-secondary/60 p-8 ring-1 ring-content-2/10 sm:mx-8 sm:p-10 lg:mx-0 lg:rounded-bl-3xl ${membershipIncludedCardClassNames}`
       >
         <h3
           id="tier-hobby"
@@ -115,61 +127,62 @@ const featuredBundles = _courses.filter((course) =>
           >Get Now</a
         >
       </div>
-      <div
-        class="card-shadow card-shadow-color relative rounded-3xl bg-secondary p-8 shadow-2xl ring-1 ring-gray-900/10 sm:p-10"
-      >
-        <h3
-          id="tier-enterprise"
-          class="text-base font-semibold leading-7 text-accent-1"
-        >
-          All-Access Membership
-        </h3>
-        <div class="mt-4 flex items-baseline gap-x-2">
-          <span class="text-5xl font-bold tracking-tight text-content">
-            <CoursePrice
-              pricingPlanId={monthlyMembershipPricingPlanId}
-              client:visible={{ rootMargin: "2160px" }}
-            />
-          </span>
-          <span class="text-base text-content">/monthly</span>
-        </div>
-        <p class="mt-6 text-base leading-7 text-content">
-          All of the Rock the JVM courses
-        </p>
-        <ul class="mt-8 space-y-3 text-sm leading-6 text-content sm:mt-10">
-          {
-            [
-              `${monthlyMembershipHours} hours of 4K content`,
-              `${monthlyMembershipLinesOfCode} lines of code written`,
-              ...categories.map(
-                (category) => `All ${category.data.name} courses`,
-              ),
-            ].map((line) => (
-              <li class="flex gap-x-3">
-                <svg
-                  class="h-6 w-5 flex-none text-accent-1"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-                {line}
-              </li>
-            ))
-          }
-        </ul>
-        <a
-          href={`https://courses.rockthejvm.com/purchase?product_id=${monthlyMembershipPricingPlanId}`}
-          aria-describedby="tier-enterprise"
-          class="mt-8 block rounded-md bg-cta px-3.5 py-2.5 text-center text-sm font-semibold text-ctatext shadow-sm hover:bg-accent-1 hover:text-content-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cta sm:mt-10"
-          >Join Now</a
-        >
-      </div>
+      {
+        includedInMembership && (
+          <div class="card-shadow card-shadow-color relative rounded-3xl bg-secondary p-8 shadow-2xl ring-1 ring-gray-900/10 sm:p-10">
+            <h3
+              id="tier-enterprise"
+              class="text-base font-semibold leading-7 text-accent-1"
+            >
+              All-Access Membership
+            </h3>
+            <div class="mt-4 flex items-baseline gap-x-2">
+              <span class="text-5xl font-bold tracking-tight text-content">
+                <CoursePrice
+                  pricingPlanId={monthlyMembershipPricingPlanId}
+                  client:visible={{ rootMargin: "2160px" }}
+                />
+              </span>
+              <span class="text-base text-content">/monthly</span>
+            </div>
+            <p class="mt-6 text-base leading-7 text-content">
+              All of the Rock the JVM courses
+            </p>
+            <ul class="mt-8 space-y-3 text-sm leading-6 text-content sm:mt-10">
+              {[
+                `${monthlyMembershipHours} hours of 4K content`,
+                `${monthlyMembershipLinesOfCode} lines of code written`,
+                ...categories.map(
+                  (category) => `All ${category.data.name} courses`,
+                ),
+              ].map((line) => (
+                <li class="flex gap-x-3">
+                  <svg
+                    class="h-6 w-5 flex-none text-accent-1"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
+                  {line}
+                </li>
+              ))}
+            </ul>
+            <a
+              href={`https://courses.rockthejvm.com/purchase?product_id=${monthlyMembershipPricingPlanId}`}
+              aria-describedby="tier-enterprise"
+              class="mt-8 block rounded-md bg-cta px-3.5 py-2.5 text-center text-sm font-semibold text-ctatext shadow-sm hover:bg-accent-1 hover:text-content-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cta sm:mt-10"
+            >
+              Join Now
+            </a>
+          </div>
+        )
+      }
     </div>
 
     {


### PR DESCRIPTION
The Rite of Passage courses are currently not part of the membership. I will add them soon, but there are some logistical challenges to it. In the meantime, I cut out the "all-access membership" card from their pages by creating a `includedInMembership` flag.