### PR TITLE
fix(article): Typo in 'Structured Concurrency in Java' article

### DIFF
--- a/src/content/articles/structured-concurrency-in-java/index.mdx
+++ b/src/content/articles/structured-concurrency-in-java/index.mdx
@@ -1002,6 +1002,7 @@ static class ShutdownOnResult<T> extends StructuredTaskScope<T> {
   }
 
   public T resultOrThrow() throws ExecutionException {
+    ensureOwnerAndJoined();
     if (firstException != null) {
       throw new ExecutionException(firstException);
     }


### PR DESCRIPTION
Fixed a typo in **Structured Concurrency in Java** article where was missing a method call