### PR TITLE
Fix: purchase links broken

### DIFF
--- a/src/components/MembershipPricingHelper.jsx
+++ b/src/components/MembershipPricingHelper.jsx
@@ -305,6 +305,8 @@ export default function Example(props) {
                 href="https://courses.rockthejvm.com/purchase?product_id=4131055"
                 aria-describedby="tier-hobby"
                 className="mt-8 block rounded-xl bg-cta px-3.5 py-2.5 text-center text-sm font-semibold text-ctatext shadow-sm hover:bg-accent-1 hover:text-content-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cta sm:mt-10"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 Join Now
               </a>
@@ -475,6 +477,8 @@ export default function Example(props) {
                 href="https://courses.rockthejvm.com/purchase?product_id=4131056"
                 aria-describedby="tier-enterprise"
                 className="mt-8 block rounded-xl bg-cta px-3.5 py-2.5 text-center text-sm font-semibold text-content-1 shadow-sm hover:bg-accent-1 hover:text-content-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cta sm:mt-10"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 Join Now
               </a>

--- a/src/pages/courses/_sections/Hero.astro
+++ b/src/pages/courses/_sections/Hero.astro
@@ -43,6 +43,8 @@ const { description, heroImage, pricingPlanId, title, active } = Astro.props;
           <a
             href={`https://courses.rockthejvm.com/purchase?product_id=${pricingPlanId}`}
             class="rounded-md bg-cta px-3.5 py-2.5 text-base font-semibold text-ctatext shadow-sm hover:bg-accent-1 hover:text-gray-100 hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Enroll now
           </a>

--- a/src/pages/courses/_sections/Pricing.astro
+++ b/src/pages/courses/_sections/Pricing.astro
@@ -124,6 +124,8 @@ const membershipIncludedCardClassNames =
               href={`https://courses.rockthejvm.com/purchase?product_id=${pricingPlanId}`}
               aria-describedby="tier-hobby"
               class="mt-8 block rounded-md px-3.5 py-2.5 text-center text-sm font-semibold text-content ring-1 ring-inset ring-cta hover:ring-accent-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cta sm:mt-10"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Get Now
             </a>
@@ -180,6 +182,8 @@ const membershipIncludedCardClassNames =
               href={`https://courses.rockthejvm.com/purchase?product_id=${monthlyMembershipPricingPlanId}`}
               aria-describedby="tier-enterprise"
               class="mt-8 block rounded-md bg-cta px-3.5 py-2.5 text-center text-sm font-semibold text-ctatext shadow-sm hover:bg-accent-1 hover:text-content-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cta sm:mt-10"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Join Now
             </a>


### PR DESCRIPTION
All purchase links on the site lead to a 404 because for some reason they're rewritten to relative links.
Right now nobody can buy anything on the site.

I've added target blank and noopener noreferrer to prevent the browser from making this rewrite,
Treating this as a P0 - will bypass review and merge once build is successful.

Will investigate why the rewrite happens suddenly and make further changes as necessary, in a separate PR.