### PR TITLE
Remove escaped url from FAQ

### DIFF
--- a/src/pages/courses/_sections/CourseFAQ.astro
+++ b/src/pages/courses/_sections/CourseFAQ.astro
@@ -29,7 +29,7 @@ const generalCourseFaqs = [
   },
   {
     question: "What if I don't like the course?",
-    answer: `Your 💰 back, no problem. Only a handful of people have ever asked for a refund on the entire site of 20+ courses, just to give you an idea. If you are not satisfied with the course, contact me at <a href="rockthejvm.com/contact" target="_blank" rel="noreferrer">`,
+    answer: `Your 💰 back, no problem. Only a handful of people have ever asked for a refund on the entire site of 20+ courses, just to give you an idea. If you are not satisfied with the course, contact me at rockthejvm.com/contact or daniel@rockthejvm.com.`,
   },
   {
     question: "How long do I have access to the course?",


### PR DESCRIPTION
The FAQ "What if I don't like the course" contains a raw HTML string `<a href="rockthejvm.com/contact" target="_blank" rel="noreferrer">`.


I just removed that and added my email and a plain text "link".
This is a trivial change, if it builds and works correctly I'll merge.