### PR TITLE
Aspect ratio of course instructor photos is off

### DIFF
--- a/src/components/Profile.astro
+++ b/src/components/Profile.astro
@@ -22,7 +22,7 @@ const author = await getEntry("authors", "daniel-ciocirlan");
     image={author.data.photo}
     imagePosition="left"
     imageRounded={true}
-    imageClassName="size-3/4"
+    imageClassName="w-3/4"
   >
     <h3>Daniel Ciocîrlan</h3>
     <article>
@@ -56,7 +56,7 @@ const author = await getEntry("authors", "daniel-ciocirlan");
           image={collaborator.frontmatter.photo}
           imagePosition="right"
           imageRounded={true}
-          imageClassName="size-3/4"
+          imageClassName="w-3/4"
         >
           <h3>In Collaboration with {collaborator.frontmatter.name}</h3>
           <div>


### PR DESCRIPTION
Profile images are being distorted on the course pages because size-3/4 explicitly sets the width and height.

![image](https://github.com/user-attachments/assets/3859ceb3-1908-4e91-8712-3563e10a9e3c)

Keeping the class as w-3/4 should maintain the dimensions of the images.

![image](https://github.com/user-attachments/assets/232bc2c6-0465-4b74-889e-60d8f43aef03)
