### PR TITLE
Fix typo on the Scala at Light Speed course page

### DIFF
--- a/src/content/courses/scala-at-light-speed/index.mdx
+++ b/src/content/courses/scala-at-light-speed/index.mdx
@@ -7,7 +7,7 @@ description: Learn Scala in the time it takes to watch a movie. This course is f
 difficulty: beginner
 excerpt: "<p>For the busy programmer: learn Scala's most important features in the time it takes to watch a movie</p>"
 faqs:
-    - question: Did you just say I can learn Kotlin in a couple of hours?
+    - question: Did you just say I can learn Scala in a couple of hours?
       answer: I did. This is my first attempt at this format. If this course works (or doesn't), I'd love to hear your feedback at rockthejvm.com/contact.
 heroImage: images/scala-at-light-speed.png
 isFree: true


### PR DESCRIPTION
The FAQ question "Did you just say I can learn Kotlin in a couple of hours" should say Scala.